### PR TITLE
Feat/weaponsforge 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,14 @@ Switches the Git global user account credentials and resets the git user's passw
 
 1. **main.bat**
    - Windows batch script to automate git user (view, edit and reset password) commands from a `~/.gitcredential` file.
-   - Follow the instructions for setting up Git Bash for usage with this script.
+   - Follow the instructions for setting up Git Bash for usage with this script at [GitBash Configuration with main.bat
+](#gitbash-configuration-with-mainbat).
 
       > **WARNING:** This method stores a Git user's password or Personal Access Token (PAT) in a `~/.gitcredential` plain-text file, which maybe unsafe. Consider using the **main-wincred.bat** script to ensure stricter Git account security using the Windows Credential Manager.
 
 2. **main-wincred.bat**
    - Windows batch script to automate git user (view, edit and reset password) commands from the Windows Credential Manager.
-   - Follow the instructions for setting up Git Bash for usage with this script.
+   - Follow the instructions for setting up Git Bash for usage with this script at [GitBash Configuration with main-wincred.bat](#gitbash-configuration-with-main-wincredbat).
 
 ## Installation
 
@@ -67,7 +68,7 @@ Configure your GitBash first with the following settings before using the script
 ### GitBash Configuration with `main-wincred.bat`
 
 1. GitBash requires no further setup when using the Windows Credential Manager for managing Git accounts.
-2. Undo the GitBash setup steps from [GitBash Configuration with `main.bat`](#gitBash-configuration-with-main.bat), if these steps were previously used.
+2. Undo the GitBash setup steps from [GitBash Configuration with `main.bat`](#gitbash-configuration-with-mainbat), if these steps were previously used.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Switches the Git global user account credentials and resets the git user's passw
    - Follow the instructions for setting up Git Bash for usage with this script at [GitBash Configuration with main.bat
 ](#gitbash-configuration-with-mainbat).
 
-      > **WARNING:** This method stores a Git user's password or Personal Access Token (PAT) in a `~/.gitcredential` plain-text file, which maybe unsafe. Consider using the **main-wincred.bat** script to ensure stricter Git account security using the Windows Credential Manager.
+      > **WARNING:** This script stores a Git user's password or Personal Access Token (PAT) in a `~/.gitcredential` plain-text file, which maybe unsafe. Consider using the **main-wincred.bat** script to ensure stricter Git account security using the Windows Credential Manager.
 
 2. **main-wincred.bat**
    - Windows batch script to automate git user (view, edit and reset password) commands from the Windows Credential Manager.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # git-switcher
 
->  Switches the Git global account credentials from a Git config file without resetting from the Windows Credentials Manager.<br>
->  Sets a git user and resets the git user's password for GitHub, GitLab, or BitBucket.
+Switches the Git global user account credentials and resets the git user's password for GitHub, GitLab, or BitBucket:
+
+- from the Windows Credential Manager using `main-wincred.bat`.
+- from a `~/.gitcredential` file using `main.bat`.
 
 
 ### Dependencies
@@ -16,16 +18,28 @@
 
 ## Content
 
-1. **main.bat**  
-Windows batch script to automate git user (view, edit and reset password) commands.
+1. **main.bat**
+   - Windows batch script to automate git user (view, edit and reset password) commands from a `~/.gitcredential` file.
+   - Follow the instructions for setting up Git Bash for usage with this script.
+
+      > **WARNING:** This method stores a Git user's password or Personal Access Token (PAT) in a `~/.gitcredential` plain-text file, which maybe unsafe. Consider using the **main-wincred.bat** script to ensure stricter Git account security.
+
+2. **main-wincred.bat**
+   - Windows batch script to automate git user (view, edit and reset password) commands from the Windows Credential Manager.
+   - Follow the instructions for setting up Git Bash for usage with this script.
 
 ## Installation
 
-1. Clone this repository.  
+1. Clone this repository.<br>
 `git clone https://github.com/weaponsforge/git-switcher.git`
-2. Follow the GitBash configuration steps from the preceeding sub-section.
 
-### GitBash Configuration (Windows OS only)
+2. Follow the GitBash Configuration Steps for `main.bat` or `main-wincred.bat` from the preceeding sub-sections.
+
+3. Read the [Usage](#usage) section for reference on using the scripts after setting up GitBash from step **# 2**.
+
+## GitBash Configuration (Windows OS only)
+
+### GitBash Configuration with `main.bat`
 
 Configure your GitBash first with the following settings before using the script.
 
@@ -50,7 +64,12 @@ Configure your GitBash first with the following settings before using the script
    - Restore the deleted lines anytime as needed.
    - Take note the git-switcher script will not work after restoring the deleted lines.
 
-## Usage 
+### GitBash Configuration with `main-wincred.bat`
+
+1. GitBash requires no further setup when using the Windows Credential Manager for managing Git accounts.
+2. Undo the GitBash setup steps from [GitBash Configuration with `main.bat`](#gitBash-configuration-with-main.bat), if these steps were previously used.
+
+## Usage
 
 Click to run the windows batch script file **main.bat**. You may need to run it as an **Administrator** if there will be privilege errors.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Switches the Git global user account credentials and resets the git user's passw
    - Windows batch script to automate git user (view, edit and reset password) commands from a `~/.gitcredential` file.
    - Follow the instructions for setting up Git Bash for usage with this script.
 
-      > **WARNING:** This method stores a Git user's password or Personal Access Token (PAT) in a `~/.gitcredential` plain-text file, which maybe unsafe. Consider using the **main-wincred.bat** script to ensure stricter Git account security.
+      > **WARNING:** This method stores a Git user's password or Personal Access Token (PAT) in a `~/.gitcredential` plain-text file, which maybe unsafe. Consider using the **main-wincred.bat** script to ensure stricter Git account security using the Windows Credential Manager.
 
 2. **main-wincred.bat**
    - Windows batch script to automate git user (view, edit and reset password) commands from the Windows Credential Manager.

--- a/main-wincred.bat
+++ b/main-wincred.bat
@@ -1,0 +1,133 @@
+::------------------------------------------------------------------------------
+:: Change the git user.name and user.email
+:: Deletes the user's git password from the Windows Credential Manager.
+:: Succeeding git fetch/pull/push will prompt for the user's Git password or
+::   Personal Access Token (PAT), storing it in the Windows Credential Manager
+:: weaponsforge;20240905
+::------------------------------------------------------------------------------
+
+@echo off
+GOTO Main
+
+
+:: Display the main menu
+:Main
+  :: Clear the input variables
+  set "gitusername="
+  set "email="
+  set "doreset="
+  set "targetname="
+  set /A choice=1
+  set /A gitrepository=4
+
+  cls
+  echo ----------------------------------------------------------
+  echo VIEWING GIT SWITCHER OPTIONS
+  echo ----------------------------------------------------------
+  echo [1] View git user config
+  echo [2] Edit git user config
+  echo [3] Exit
+  set /p choice="Select option:"
+
+  (if %choice% EQU 1 (
+    GOTO ViewUserConfig
+  ) else if %choice% EQU 2 (
+    GOTO SetUserConfig
+  ) else if %choice% EQU 3 (
+    EXIT /B 0
+  ))
+EXIT /B 0
+
+
+:: Prompt for git config username and email
+:SetUserConfig
+  cls
+  echo ----------------------------------------------------------
+  echo EDIT GIT USER CONFIG DETAILS
+  echo ----------------------------------------------------------
+
+  set /p gitusername="Enter git user.name:"
+  git config --global user.name %gitusername%
+
+  set /p email="Enter git user.email:"
+  git config --global user.email %email%
+
+  echo Updated git user config...
+  set /p doreset=Would you like to reset the password? [Y/n]:
+
+  echo.%doreset% | findstr /C:"Y">nul && (
+    GOTO ResetPassword
+  ) || (
+    GOTO Main
+  )
+EXIT /B 0
+
+
+:: Display the current git user config
+:ViewUserConfig
+  cls
+  echo ----------------------------------------------------------
+  echo GIT USER CONFIG DETAILS (global)
+  echo ----------------------------------------------------------
+
+  echo|set /p=Username:
+  git config --get user.name
+
+  echo|set /p=Email:
+  git config --get user.email
+
+  set /p choice=Press Enter to continue...
+  GOTO Main
+EXIT /B 0
+
+
+:: Delete the password for the newly-set git user so it will be
+:: prompted on the next git operation
+:ResetPassword
+  echo Which Git account password would you like to reset?
+  echo [1] Github
+  echo [2] Gitlab
+  echo [3] BitBucket
+  echo [4] Exit
+  set /p gitrepository="Select option:"
+
+  (if %gitrepository% EQU 1 (
+    set targetname=git:https://github.com
+  ) else if %gitrepository% EQU 2 (
+    set targetname=git:https://gitlab.com
+  ) else if %gitrepository% EQU 3 (
+    set targetname=git:https://bitbucket.org
+  ) else (
+    GOTO Main
+  ))
+
+  :: Delete Git credentials in the Windows Credential Manager
+  for /f "delims=" %%i in ('cmdKey /delete:%targetname% 2^>^&1') do set "output=%%i"
+
+  echo.
+  echo %output%
+
+  GOTO ExitResetPassword
+EXIT /B 0
+
+
+:: Exit from the git reset password
+:ExitResetPassword
+  :: Delete temporary git credentials file
+  echo The Git credentials were successfully deleted from the
+  echo Windows Credential Manager, if they were present.
+  GOTO ProcessError
+EXIT /B 0
+
+
+:: Process warning messages
+:ProcessError
+  set /p choice=Press Enter to continue...
+  GOTO Main
+EXIT /B 0
+
+
+:: Exit for critical errors
+:ProcessExit
+  set /p choice=Press Enter to continue...
+EXIT /B 0

--- a/main.bat
+++ b/main.bat
@@ -1,8 +1,8 @@
-::----------------------------------------------------------
+::-------------------------------------------------------------
 :: Change the git user.name and user.email
-:: Reset the user's git password
+:: Reset the user's git password from a ~/.gitcredential file
 :: weaponsforge;20191026
-::----------------------------------------------------------
+::-------------------------------------------------------------
 
 @echo off
 GOTO Main
@@ -76,7 +76,7 @@ EXIT /B 0
   echo ----------------------------------------------------------
   echo GIT USER CONFIG DETAILS (global)
   echo ----------------------------------------------------------
-  
+
   echo|set /p=Username:
   git config --get user.name
 


### PR DESCRIPTION
- Use the Windows Credential Manager for managing Git account credentials, [#6](https://github.com/weaponsforge/git-switcher/issues/6) 