### PR TITLE
Fix: git provider-username string matching

### DIFF
--- a/main-wincred.bat
+++ b/main-wincred.bat
@@ -246,7 +246,7 @@ EXIT /B 0
   set "gitUsername=%~2"
   set hasError=false
 
-  for /f "tokens=*" %%a in ('findstr /r "^%gitProvider%|%gitUsername%" "%envFile%"') do (
+  for /f "tokens=*" %%a in ('findstr /r /c:"^%gitProvider%|%gitUsername%|" "%envFile%"') do (
     set USER_DATA_STRING="%%a"
   )
 


### PR DESCRIPTION
- Fix: exact git provider|username| string matching - avoid partial string matches, [#15](https://github.com/weaponsforge/git-switcher/issues/15)